### PR TITLE
Fix typos and port

### DIFF
--- a/jmx-to-grafana/README.md
+++ b/jmx-to-grafana/README.md
@@ -34,7 +34,7 @@ Build Grafana dashboard to plot real-time metrics of Geode cluster.
 
 #### Start JMX To InfluxDB loader
 The `jmx-to-grafana` reads every minute (`cronExpression="0 0/1 * * * ?"`) the JMX metrics from
-Geode MBean Server (`http://localhost:1199`) and loads them into InfluxDB database (`GeodeJmx`). The InfluxDB is
+Geode MBean Server (`http://localhost:1099`) and loads them into InfluxDB database (`GeodeJmx`). The InfluxDB is
 running at `http://localhost:8086`.
 
 The Grafana server (`http://localhost:3000`) uses the `GeodeJmx` time-series database to plot various `Real-Time` dashboards
@@ -42,7 +42,7 @@ The Grafana server (`http://localhost:3000`) uses the `GeodeJmx` time-series dat
 ```
 java -jar ./target/jmx-to-grafana-0.0.1-SNAPSHOT.jar \
    --mbeanHostName=localhost \
-   --mbeanPort=1199 \
+   --mbeanPort=1099 \
    --influxUrl=http://localhost:8086 \
    --influxDatabaseName=GeodeJmx \
    --cronExpression="0 0/1 * * * ?"
@@ -59,7 +59,7 @@ java -jar ./target/jmx-to-grafana-0.0.1-SNAPSHOT.jar \
 | influxRetentionPolicy | autogen | InfluxDB retention policy |
 | mbeanHostName | None |  |
 | influxDatabaseName | GeodeJmx | Database to load the jmx metrics into. Same database is used to load metrics for cluster members. The `member` is used to distinct the time-series form different members. |
-| mbeanPort | 1190 |  |
+| mbeanPort | 1099 |  |
 | cronExpression | 0 0/1 * * * ? | Time interval for pulling JMX metrics from Geode and load them into InfluxDB. Defaults to 1m. Use `--cronExpression="..."` syntax to set the expression from the command line. |
 
 ###### Exported Geode MBeans

--- a/jmx-to-grafana/README.md
+++ b/jmx-to-grafana/README.md
@@ -40,11 +40,11 @@ running at `http://localhost:8086`.
 The Grafana server (`http://localhost:3000`) uses the `GeodeJmx` time-series database to plot various `Real-Time` dashboards
 
 ```
-java -jar ./target/jmx-to-grafana-0.0.1-SNAPSHOT.jar
-   --mbeanHostName=localhost
-   --mbeanPort=1199
-   --influxUrl=http://localhost:8086
-   --influxDatabaseName=GeodeJmx
+java -jar ./target/jmx-to-grafana-0.0.1-SNAPSHOT.jar \
+   --mbeanHostName=localhost \
+   --mbeanPort=1199 \
+   --influxUrl=http://localhost:8086 \
+   --influxDatabaseName=GeodeJmx \
    --cronExpression="0 0/1 * * * ?"
 ```
 

--- a/jmx-to-grafana/src/main/resources/application.properties
+++ b/jmx-to-grafana/src/main/resources/application.properties
@@ -8,6 +8,6 @@ cleanDatabaseOnStart=false
 influxDatabaseName=GeodeJmx
 
 mbeanHostName=localhost
-mbeanPort=1199
+mbeanPort=1099
 
 cronExpression=0 0/1 * * * ?

--- a/statistics-to-grafana/README.md
+++ b/statistics-to-grafana/README.md
@@ -1,7 +1,7 @@
 # Analyse Apache Geode & GemFire Statistics With Grafana
 
-[Apache Geode](http://geode.apache.org/) can collect [Statistics](http://geode.apache.org/docs/guide/managing/statistics/chapter_overview.html) about the distributed system and persist it in archive files. The `StatisticsToGrafana` tool helps to load the archive files in time-series databases such as InfluxDB used to feed [Gfafana](http://grafana.org/) dashboards. 
-Use the stack to build comprehensive [Gfafana](http://grafana.org/) dashboards to visualize, analyse and compare statistics data from different cluster members or even different Geode clusters.
+[Apache Geode](http://geode.apache.org/) can collect [Statistics](http://geode.apache.org/docs/guide/managing/statistics/chapter_overview.html) about the distributed system and persist it in archive files. The `StatisticsToGrafana` tool helps to load the archive files in time-series databases such as InfluxDB used to feed [Grafana](http://grafana.org/) dashboards. 
+Use the stack to build comprehensive [Grafana](http://grafana.org/) dashboards to visualize, analyse and compare statistics data from different cluster members or even different Geode clusters.
 
 ## Build
 Get the source code from github
@@ -16,12 +16,12 @@ mvn clean install
 
 ## Quick Start
 Build Grafana dashboard to analyze the statistics files collected on two Geode instances (e.g. members). 
-[Grafana](http://docs.grafana.org/installation) and [InfluxDB](https://docs.influxdata.com/influxdb/v1.1/introduction/installation) have to be installed first. Samples below expect InfluxDB on `http://localhost:8086` and Grafana on `http://localhost:30000`. 
+[Grafana](http://docs.grafana.org/installation) and [InfluxDB](https://docs.influxdata.com/influxdb/v1.1/introduction/installation) have to be installed first. Samples below expect InfluxDB on `http://localhost:8086` and Grafana on `http://localhost:3000`. 
 
 #### Load statistics into an InfluxDB database
 If the target InfluxDB database (`GeodeArchive` for example) doesn't exist yet create one. You can do it through the `influx` command-line tool:
 ```
-influx> create database GoedeArchive
+influx> create database GeodeArchive
 influx> show databases
 ```
 or with the help of the `--cleanDatabaseOnLoad=true` parameter.  Later removes and creates again the time-series database. 

--- a/statistics-to-grafana/README.md
+++ b/statistics-to-grafana/README.md
@@ -28,18 +28,18 @@ or with the help of the `--cleanDatabaseOnLoad=true` parameter.  Later removes a
 
 Load the `server1_StatisticsArchiveFile.gfs` file containing historical statistics for `server1` cluster member into influx database `GeodeArchive`. Set the measurement archiveMember tag to ‘server1’.
 ```
-java -jar ./target/statistics-to-grafana-0.0.1-SNAPSHOT.jar 
-   --influxUrl=http://localhost:8086 
-   --influxDatabaseName=GeodeArchive 
-   --geodeMemberName=server1 
+java -jar ./target/statistics-to-grafana-0.0.1-SNAPSHOT.jar \
+   --influxUrl=http://localhost:8086 \
+   --influxDatabaseName=GeodeArchive \
+   --geodeMemberName=server1 \
    --archiveFile=server1_StatisticsArchiveFile.gfs
 ```
 Load the `server2_StatisticsArchiveFile.gfs` file containing historical statistics for `server2` cluster member in the same influx database `GeodeArchive`:
 ```
-java -jar ./target/statistics-to-grafana-0.0.1-SNAPSHOT.jar 
-   --influxUrl=http://localhost:8086 
-   --influxDatabaseName=GeodeArchive 
-   --geodeMemberName=server2 
+java -jar ./target/statistics-to-grafana-0.0.1-SNAPSHOT.jar \
+   --influxUrl=http://localhost:8086 \
+   --influxDatabaseName=GeodeArchive \
+   --geodeMemberName=server2 \
    --archiveFile=server2_StatisticsArchiveFile.gfs
 ```
 > Note that the statistics from both files is loaded in the same database: `GeodeArchive`! 


### PR DESCRIPTION
- Fixed some typos.
- Fixed Grafana server default port.
- Added line-continuation char to ease copy-and-paste into unix shell.
- Changed Geode JMX default port that seems to be 1099 for Geode [1.1](http://geode.apache.org/docs/guide/11/managing/management/configuring_rmi_connector.html) and [1.0](http://geode.apache.org/docs/guide/10/managing/management/configuring_rmi_connector.html).